### PR TITLE
Fix error with type in contacs list if we have yourself in contact

### DIFF
--- a/mtproto.go
+++ b/mtproto.go
@@ -244,8 +244,10 @@ func (m *MTProto) GetContacts() error {
 
 	contacts := make(map[int32]TL_userContact)
 	for _, v := range list.users {
-		v := v.(TL_userContact)
-		contacts[v.id] = v
+		switch v.(type) {
+		case TL_userContact:
+			contacts[v.id] = v
+		}
 	}
 	fmt.Printf(
 		"\033[33m\033[1m%10s    %10s    %-30s    %-20s\033[0m\n",


### PR DESCRIPTION
Fix error 

```
panic: interface conversion: mtproto.TL is mtproto.TL_userSelf, not mtproto.TL_userContact
```
